### PR TITLE
Only list iota once

### DIFF
--- a/constexpr-numeric/constexpr-numeric.bs
+++ b/constexpr-numeric/constexpr-numeric.bs
@@ -77,7 +77,6 @@ This proposal is to add `constexpr` to the following function templates in `<num
 - `transform_exclusive_scan`
 - `transform_inclusive_scan`
 - `adjacent_difference`
-- `iota`
 
 # Proposed wording relative to N4810 # {#wording}
 

--- a/constexpr-numeric/constexpr-numeric.html
+++ b/constexpr-numeric/constexpr-numeric.html
@@ -1227,10 +1227,10 @@ Possible extra rowspan handling
       text-align: center;
     }
   </style>
-  <meta content="Bikeshed version 8ac92da89bb2253e0da87e20a9b9caa745f5f5b6" name="generator">
+  <meta content="Bikeshed version d76ab51ece93be5af3a1621c820b89fd4f9cc432" name="generator">
   <link href="https://elbeno.github.io/isocpp/constexpr-numeric/constexpr-numeric.html" rel="canonical">
   <link href="https://isocpp.org/favicon.ico" rel="icon">
-  <meta content="3c800b0aee2ae332f5240f14867c0c1cf73aec29" name="document-revision">
+  <meta content="c4c9d2be749a83261369e348e1e0830d9eeaa407" name="document-revision">
 <style>
 .ins, ins, ins *, span.ins, span.ins * {
   background-color: rgb(200, 250, 200);
@@ -1534,8 +1534,6 @@ have been overlooked.</p>
      <p><code class="highlight"><c- n>transform_inclusive_scan</c-></code></p>
     <li data-md>
      <p><code class="highlight"><c- n>adjacent_difference</c-></code></p>
-    <li data-md>
-     <p><code class="highlight"><c- n>iota</c-></code></p>
    </ul>
    <h2 class="heading settled" data-level="4" id="wording"><span class="secno">4. </span><span class="content">Proposed wording relative to N4810</span><a class="self-link" href="#wording"></a></h2>
    <p>Exactly as one would expect: add <code class="highlight"><c- k>constexpr</c-></code> to the function templates listed above where they do not accept an <code class="highlight"><c- n>ExecutionPolicy</c-></code>.</p>


### PR DESCRIPTION
Problem:
- `iota` is listed twice in the list of function templates that the
  paper proposes adding `constexpr` to.

Solution:
- Remove the last occurence of `iota` such that `iota` is only listed
  exactly once in the list.